### PR TITLE
Replace flask-jwt with flask-jwt-extended

### DIFF
--- a/project/views/views.py
+++ b/project/views/views.py
@@ -2,8 +2,8 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 from flask import request, jsonify
-from flask_jwt import jwt_required, current_identity
-
+from flask_jwt_extended import (create_access_token,create_refresh_token,
+    get_jwt_identity,jwt_required)
 from project.views import views_bp
 from project.views.oauth import jwt, authenticate
 
@@ -42,9 +42,13 @@ def login():
         if not user:
             raise UserNotFoundException("User not found!")
 
-        access_token = jwt.jwt_encode_callback(user)
+        access_token = create_access_token(identity=user.id)
+        refresh_token = create_refresh_token(user.id)
 
-        resp = jsonify({"access_token": str(access_token, "utf-8")})
+        resp = jsonify({
+          "access_token": str(access_token, "utf-8"),
+          "refresh_token": str(refresh_token,"utf-8")
+          })
         resp.status_code = 200
 
         # add token to response headers - so SwaggerUI can use it
@@ -71,7 +75,7 @@ def protected():
       200:
         description: User successfully accessed the content.
     """
-    resp = jsonify({"protected": "{}".format(current_identity)})
+    resp = jsonify({"protected": "{}".format(get_jwt_identity())})
     resp.status_code = 200
 
     return resp

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ flasgger==0.8.1
 Flask==0.12.2
 Flask-Bcrypt==0.7.1
 Flask-Injector==0.10.1
-Flask-JWT==0.3.2
+Flask-JWT-Extended==3.24.1
 Flask-Login==0.4.1
 Flask-OpenTracing==0.1.8
 Flask-Script==2.0.6


### PR DESCRIPTION
The routes and functions within have been replaced to use flask-jwt-extended which provides much more functionality compared to flask-jwt.

In correspondence to issue  python-microservices/pyms#66 

A new refresh token route has also been added